### PR TITLE
Restore the aws-ssh-domain property in  ~/.aws/config feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Flags:
 Use "aws-ssh [command] --help" for more information about a command.
 ```
 
+#### Additional ~/.aws/config properties
+
+You can add an additonal property to AWS profiles like
+
+```ini
+
+[profile your_profile]
+...
+aws-ssh-domain = domain.com
+```
+
+To have the domain appended to the instance name, so in the SSH config it becomes `{profile}.{instance_name}.{domain}`
+
 ### Environment variables
 
 aws-ssh uses [viper](https://github.com/spf13/viper) under the hood, so it supports taking environment variables that correspond to the flags out of the box.

--- a/lib/aws.go
+++ b/lib/aws.go
@@ -163,6 +163,9 @@ func TraverseProfiles(profiles []ProfileConfig, noProfilePrefix bool) ([]Process
 						name = getInstanceCanonicalName("", instanceName, instanceIndex)
 					}
 					entry.Names = append(entry.Names, name, entry.InstanceID, fmt.Sprintf("%s.%s", entry.Address, entry.ProfileConfig.Name))
+					if summary.Domain != "" {
+						entry.Names = append(entry.Names, fmt.Sprintf("%s.%s", name, summary.Domain))
+					}
 					profileSSHEntries = append(profileSSHEntries, entry)
 				}
 			}


### PR DESCRIPTION
Add documentation
Fixes #14
