### PR TITLE
Dont fail and quit when a single (or multiple) credentials fail

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -22,8 +22,7 @@ allowing to automatically fill those values in.
 		cache := cache.NewYAMLCache(viper.GetString("cache-dir"))
 		profileSummaries, err := lib.TraverseProfiles(viper.Get("profilesConfig").([]lib.ProfileConfig), viper.GetBool("no-profile-prefix"))
 		if err != nil {
-			log.WithError(err).Error("got some errors")
-			return
+			log.WithError(err).Warn("got some errors")
 		}
 
 		var sshEntries []lib.SSHEntry

--- a/lib/reconf.go
+++ b/lib/reconf.go
@@ -13,8 +13,7 @@ import (
 func Reconf(profiles []ProfileConfig, filename string, noProfilePrefix bool) {
 	profileSummaries, err := TraverseProfiles(profiles, noProfilePrefix)
 	if err != nil {
-		log.WithError(err).Error("got some errors")
-		return
+		log.WithError(err).Warn("got some errors")
 	}
 
 	var sshEntries []SSHEntry


### PR DESCRIPTION
This allows multiple different aws profiles to have their own credentials that dont specifically work with aws-ssh